### PR TITLE
Remove mobile minigames

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -3,8 +3,22 @@ import ReactDOM from "react-dom";
 import App from "../src/App";
 
 // sample test
-it("renders without crashing", () => {
-    const div = document.createElement("div");
-    ReactDOM.render(<App />, div);
-    ReactDOM.unmountComponentAtNode(div);
+describe("simple rendering", () => {
+    beforeAll(() => {
+        Object.defineProperty(window, "matchMedia", {
+            value: jest.fn(() => {
+                return {
+                    matches: true,
+                    addEventListener: jest.fn(),
+                    removeEventListener: jest.fn()
+                };
+            })
+        });
+    });
+
+    it("renders without crashing", () => {
+        const div = document.createElement("div");
+        ReactDOM.render(<App />, div);
+        ReactDOM.unmountComponentAtNode(div);
+    });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,6 +44,7 @@ export default class App extends React.Component<IProps, IState> {
         super(props);
 
         const playerStats = new PlayerStats();
+		const isMobile = window.matchMedia("only screen and (max-width: 760px)").matches;
 
         //TODO: should we auto allocate a dummy player name or allow user to input their own?
         this.name = "P1";
@@ -53,11 +54,14 @@ export default class App extends React.Component<IProps, IState> {
         for (const w of config.events.seasonal) {
             seasons.push(w.map(this.eventManager.get.bind(this.eventManager)));
         }
-        const eventTracker = new EventTracker(
-            config.events.pool.map(this.eventManager.get.bind(this.eventManager)),
+        let eventTracker = new EventTracker(
+			config.events.pool.map(this.eventManager.get.bind(this.eventManager)),
             config.events.followUp.map(this.eventManager.get.bind(this.eventManager)),
-            seasons
+			seasons
         );
+		if (isMobile) {
+			eventTracker.removeMobiles(this.choiceManager);
+		}
         let firstEvent = eventTracker.getNextEvent(0);
         this.minigameManager = new MinigamesManager(minigames);
         this.state = {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,7 +44,7 @@ export default class App extends React.Component<IProps, IState> {
         super(props);
 
         const playerStats = new PlayerStats();
-		const isMobile = window.matchMedia("only screen and (max-width: 760px)").matches;
+        const isMobile = window.matchMedia("only screen and (max-width: 760px)").matches;
 
         //TODO: should we auto allocate a dummy player name or allow user to input their own?
         this.name = "P1";
@@ -55,13 +55,13 @@ export default class App extends React.Component<IProps, IState> {
             seasons.push(w.map(this.eventManager.get.bind(this.eventManager)));
         }
         let eventTracker = new EventTracker(
-			config.events.pool.map(this.eventManager.get.bind(this.eventManager)),
+            config.events.pool.map(this.eventManager.get.bind(this.eventManager)),
             config.events.followUp.map(this.eventManager.get.bind(this.eventManager)),
-			seasons
+            seasons
         );
-		if (isMobile) {
-			eventTracker.removeMobiles(this.choiceManager);
-		}
+        if (isMobile) {
+            eventTracker.removeMobiles(this.choiceManager);
+        }
         let firstEvent = eventTracker.getNextEvent(0);
         this.minigameManager = new MinigamesManager(minigames);
         this.state = {

--- a/src/trackers/EventTracker.ts
+++ b/src/trackers/EventTracker.ts
@@ -1,5 +1,6 @@
 import { IEvent } from "../events/core";
 import { GamePlayMode } from "../events/core";
+import ChoicesManager from "../events/ChoicesManager";
 
 export default class EventTracker {
     readonly SEASONAL_CHANCE = 30;
@@ -11,6 +12,17 @@ export default class EventTracker {
         this.pool = eventPool;
         this.queue = eventQueue;
         this.seasonal = seasonalPool;
+    }
+
+    public removeMobiles(cm: ChoicesManager) {
+        this.pool = this.pool.filter(evt =>
+                                     evt.choices.map(cm.get.bind(cm))
+                                     .every(c => c.minigame === ""));
+        for (let i = 0; i < this.seasonal.length; ++i) {
+            this.seasonal[i] = this.seasonal[i].filter(evt =>
+                                                       evt.choices.map(cm.get.bind(cm))
+                                                       .every(c => c.minigame === ""));
+        }
     }
 
     public getNextEvent(week: number): IEvent {


### PR DESCRIPTION
# :ship: Pull Request

## :question: Purpose

**Give a brief description of your changes:** Remove mobile events iff the user is using a mobile phone. Only happens at the start, and doesn't work if you change the screens half-way in between. Though if you change it halfway in between, good job.

## :hammer: Validation Strategy

**Describe how you verified your changes (if applicable):** I played it on desktop and on mobile. Works on both and I am never soft-locked by the game not loading (because they were **removed**).

## :tickets: Ticket(s)

Closes #108