### PR TITLE
Add unity build to public directory before npm build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ cache:
   - node_modules
 script:
 - npm install
+- scripts/unity_fetch.sh
 - scripts/build_check.sh
 deploy:
   local-dir: "./build"


### PR DESCRIPTION
# :ship: Pull Request

## :question: Purpose

**Give a brief description of your changes:** Add unity build to public directory before the npm build. Since the npm build command copies the entire `public` directory into the build directory, we don't need to copy it manually.

## :hammer: Validation Strategy

**Describe how you verified your changes (if applicable):** IDK. But I read a lot of docs on this. Should be easy to verify once we merge this.

## :tickets: Ticket(s)

Closes #119 