### PR TITLE
Fix events responsible for loading minigames in events.json

### DIFF
--- a/src/events.json
+++ b/src/events.json
@@ -82,7 +82,7 @@
 		],
 		"hasBottomBoxBorder": false,
 		"hasInnerFill": true,
-		"gamePlayMode": "Minigame"
+		"gamePlayMode": "Comics"
 	},
 	"CryMidtermPaperEvent": {
 		"prompt": "You failed your latest midterm...",
@@ -123,7 +123,7 @@
 		],
 		"hasBottomBoxBorder": true,
 		"hasInnerFill": true,
-		"gamePlayMode": "Minigame"
+		"gamePlayMode": "Comics"
 	},
 	"ImagineDayEvent": {
 		"prompt": "It's Imagine Day!",


### PR DESCRIPTION
# :ship: Pull Request

## :question: Purpose

The `gamePlayMode` specified in the `events.json` was wrongly set to `Minigame` for the events responsible for loading the minigames. The unity component will only attempt to a binary for a minigame if the current event's game play mode is set to `Minigame`, and the only events this is the case for are created at runtime. Because of this wrong setting, the unity component attempts to load the binaries for an event with no binaries associated, and an error occurs.

## :hammer: Validation Strategy

Minigames now work again.

## :tickets: Ticket(s)

Closes #132 
